### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ YubiHSM Rust community bindings.
 
 ## Build instructions
 
-We are still working on a nix-based build. For now,
+We are still working on a pure nix-based build. For now,
 you can build using `cargo` and `cabal`:
 
-- get those tools (under NixOS that would be `nix-shell -p cabal-install cargo`
+- `nix develop`
 - `cd rustbits`
 - `cargo build --release`
 - `cd `..`


### PR DESCRIPTION
This reflects how we build the project now, without pure Nix. It just instructs to get a shell via `nix develop` and build the project imperatively as you would normally without Nix. There will be the ability to build the project entirely with Nix in the future, but since this is difficult due to the integration we have to develop between Cargo and Haskell, we are recommending `nix develop` with imperative for now.